### PR TITLE
Change FL_NORMAL_SIZE extern to importc

### DIFF
--- a/private/enumerations.nim
+++ b/private/enumerations.nim
@@ -355,7 +355,7 @@ const
 type
   Fontsize* {.importc: "Fl_Fontsize", header: flh.} = cint
 
-var FL_NORMAL_SIZE* {.extern: "FL_NORMAL_SIZE".}: Fontsize
+var FL_NORMAL_SIZE* {.importc: "FL_NORMAL_SIZE".}: Fontsize
 
 type
   Color* {.importc: "Fl_Color", header: flh.} = cint


### PR DESCRIPTION
This fixes a lot of weird bugs:
* Last argument labels are immediately displayed as they do in C++
* Clang compilation succeeds
* FlTextDisplay doesn't crash when `buffer` is set